### PR TITLE
Update buildapp.yml to upload Artifact

### DIFF
--- a/.github/workflows/buildapp.yml
+++ b/.github/workflows/buildapp.yml
@@ -104,7 +104,6 @@ jobs:
       - name: Upload Artifact
         uses: actions/upload-artifact@v3
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           UYOU_VERSION: ${{ github.event.inputs.uyou_version }}
           YOUTUBE_VERSION: ${{ github.event.inputs.youtube_version }}
         with:

--- a/.github/workflows/buildapp.yml
+++ b/.github/workflows/buildapp.yml
@@ -1,7 +1,7 @@
 # Original idea by @ISnackable. Thanks to him for handling the hardest parts!
 # https://github.com/ISnackable/CercubePlus/blob/main/.github/workflows/Build.yml
 
-name: Build and Release uYouPlus
+name: Build uYouPlus Artifact
 
 on:
   workflow_dispatch:
@@ -32,9 +32,6 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - name: Set Env
-        run: echo "workspace=$GITHUB_WORKSPACE" >> $GITHUB_ENV
-
       - name: Checkout Main
         uses: actions/checkout@v3
         with:
@@ -60,7 +57,7 @@ jobs:
           mv $TMP/sdks-main/*.sdk $THEOS/sdks
           rm -r main.zip $TMP
         env:
-          THEOS: ${{ env.workspace }}/theos
+          THEOS: ${{ github.workspace }}/theos
 
       - name: Setup Theos Jailed
         uses: actions/checkout@v3
@@ -74,11 +71,11 @@ jobs:
         run: |
           ./theos-jailed/install
         env:
-          THEOS: ${{ env.workspace }}/theos
+          THEOS: ${{ github.workspace }}/theos
 
       - name: Download Dylibs
         run: |
-          curl "https://raw.githubusercontent.com/Muirey03/RemoteLog/master/RemoteLog.h" --output "$THEOS/include/RemoteLog.h"  
+          curl "https://raw.githubusercontent.com/Muirey03/RemoteLog/master/RemoteLog.h" --output "$THEOS/include/RemoteLog.h"
           curl "https://miro92.com/repo/debs/com.miro.uyou_${{ env.UYOU_VERSION }}_iphoneos-arm.deb" --output "./main/Tweaks/uYou/com.miro.uyou_${{ env.UYOU_VERSION }}_iphoneos-arm.deb"
           wget "$YOUTUBE_URL" --no-verbose -O ./main/YouTube.ipa
           dpkg-deb -x "./main/Tweaks/uYou/com.miro.uyou_${{ env.UYOU_VERSION }}_iphoneos-arm.deb" ./main/Tweaks/uYou/
@@ -87,42 +84,30 @@ jobs:
           cp -R ./main/Extensions/*.appex ./main/tmp/Payload/YouTube.app/PlugIns
 
         env:
-          THEOS: ${{ env.workspace }}/theos
+          THEOS: ${{ github.workspace }}/theos
           UYOU_VERSION: ${{ github.event.inputs.uyou_version }}
           YOUTUBE_URL: ${{ github.event.inputs.decrypted_youtube_url }}
-          YOUTUBE_VERSION: ${{ github.event.inputs.youtube_version }}
 
       - name: Fix compiling && Build Package
         id: build_package
         run: |
-          cd ${{ env.workspace }}/main
-          (cd ${{ env.workspace }}/main/Tweaks/YouPiP && sed -i '' "14s#.*#YouPiP_FRAMEWORKS = AVKit AVFoundation UIKit#g" ./Makefile)
+          cd ${{ github.workspace }}/main
+          (cd ${{ github.workspace }}/main/Tweaks/YouPiP && sed -i '' "14s#.*#YouPiP_FRAMEWORKS = AVKit AVFoundation UIKit#g" ./Makefile)
           make package FINALPACKAGE=1
+          (mv "packages/$(ls -t packages | head -n1)" "packages/uYouPlus_${{ env.YOUTUBE_VERSION  }}_${{ env.UYOU_VERSION }}.ipa")
           echo "::set-output name=package::$(ls -t packages | head -n1)"
         env:
-          THEOS: ${{ env.workspace }}/theos
+          THEOS: ${{ github.workspace }}/theos
+          UYOU_VERSION: ${{ github.event.inputs.uyou_version }}
+          YOUTUBE_VERSION: ${{ github.event.inputs.youtube_version }}
 
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           UYOU_VERSION: ${{ github.event.inputs.uyou_version }}
           YOUTUBE_VERSION: ${{ github.event.inputs.youtube_version }}
         with:
-          tag_name: v${{ env.YOUTUBE_VERSION }}-${{ env.UYOU_VERSION }}-(${{ github.run_number }})
-          release_name: v${{ env.YOUTUBE_VERSION }}-${{ env.UYOU_VERSION }}-(${{ github.run_number }})
-          draft: true
-          prerelease: false
-
-      - name: Upload Release Asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          UYOU_VERSION: ${{ github.event.inputs.uyou_version }}
-          YOUTUBE_VERSION: ${{ github.event.inputs.youtube_version }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ${{ env.workspace }}/main/packages/${{ steps.build_package.outputs.package }}
-          asset_name: uYouPlus_${{ env.YOUTUBE_VERSION  }}_${{ env.UYOU_VERSION }}.ipa
-          asset_content_type: application/vnd.debian.binary-package
+          name: uYouPlus_${{ env.YOUTUBE_VERSION  }}_${{ env.UYOU_VERSION }}
+          path: ${{ github.workspace }}/main/packages/${{ steps.build_package.outputs.package }}
+          if-no-files-found: error


### PR DESCRIPTION
Close #197. This PR will now use the [actions/upload-artifact@v3](https://github.com/actions/upload-artifact) actions, not relying on the `GITHUB_TOKEN` secret.

![image](https://user-images.githubusercontent.com/52971804/172991563-38a8bd33-d65d-47e7-95b4-6c22c699e99e.png)
