### PR TITLE
[uYouPlus Workflow Fix] iOS 15 SDK Fix

### DIFF
--- a/.github/workflows/buildapp.yml
+++ b/.github/workflows/buildapp.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Download iOS 15 SDK
         run: |
-          curl -LO https://github.com/chrisharper22/sdks/archive/main.zip
+          curl -LO https://github.com/arichorn/sdks/archive/main.zip
           TMP=$(mktemp -d)
           unzip -qq main.zip -d $TMP
           mv $TMP/sdks-main/*.sdk $THEOS/sdks


### PR DESCRIPTION
chrisharper22 recently committed a new change and it’s a new SDK for iOS 16 Beta 3 which caused a whole lot of problems or errors when building the ipa on GitHub. So I forked their sdk repo and removed their new commit and then changed the sdk url just so everyone will be able to build their custom ipas for YouTube again! 👍
(this also effects CercubePlus)