### PR TITLE
Update Japanese localization

### DIFF
--- a/lang/uYouPlus.bundle/ja.lproj/Localizable.strings
+++ b/lang/uYouPlus.bundle/ja.lproj/Localizable.strings
@@ -1,25 +1,25 @@
 // Settings
 
 "KILL_APP" = "YouTubeを閉じる";
-"KILL_APP_DESC" = "ここをタップしてYouTubeを終了できます!";
+"KILL_APP_DESC" = "ここをタップしてYouTubeを終了できます！";
 
 "HIDE_PREVIOUS_AND_NEXT_BUTTON" = "前後の動画のボタンを非表示";
 "HIDE_PREVIOUS_AND_NEXT_BUTTON_DESC" = "コントロールのオーバーレイで前後の動画のボタンを非表示にします。";
 
 "YT_MINIPLAYER" = "すべての動画でミニプレーヤーを有効にする";
-"YT_MINIPLAYER_DESC" = "例: 子供向けの動画";
+"YT_MINIPLAYER_DESC" = "例: 子ども向けの動画";
 
 "CAST_CONFIRM" = "キャストする前に確認画面を表示する (YTCastConfirm)";
 "CAST_CONFIRM_DESC" = "誤ってテレビにキャストしないよう、前に確認画面を表示します。";
 
 "HIDE_HOVER_CARD" = "動画終わりのホバーカードを非表示 (YTNoHoverCards)";
-"HIDE_HOVER_CARD_DESC" = "動画終わりのホバーカード(サムネ)を非表示にします。";
+"HIDE_HOVER_CARD_DESC" = "動画の最後のホバーカード(サムネイル)を非表示にします。";
 
 "NEW_MINIPLAYER_STYLE" = "新しいミニプレーヤー・バーを使う (BigYTMiniPlayer)";
-"NEW_MINIPLAYER_STYLE_DESC" = "アプリを再起動してください。";
+"NEW_MINIPLAYER_STYLE_DESC" = "アプリの再起動が必要です。";
 
-"YT_RE_EXPLORE" = "ショートのタブを「見つける」タブに置き換える (YTReExplore)";
-"YT_RE_EXPLORE_DESC" = "アプリを再起動してください。";
+"YT_RE_EXPLORE" = "ショートタブを探索タブに置き換える (YTReExplore)";
+"YT_RE_EXPLORE_DESC" = "アプリの再起動が必要です。";
 
 "HIDE_SUBTITLES_BUTTON" = "字幕ボタンを非表示";
 "HIDE_SUBTITLES_BUTTON_DESC" = "動画コントロールのオーバーレイから字幕ボタンを非表示にします。";
@@ -31,19 +31,19 @@
 "AUTO_FULLSCREEN_DESC" = "動画を自動でフルスクリーンにします。";
 
 "HIDE_HUD_MESSAGES" = "HUDのメッセージを非表示";
-"HIDE_HUD_MESSAGES_DESC" = "例: 字幕がon/offです、ループ再生は有効です 等";
+"HIDE_HUD_MESSAGES_DESC" = "例: 字幕がオン/オフになりました、ループ再生はオンになっています 等";
 
 "OLED_DARKMODE" = "有機ELダークモード (実験的機能)";
-"OLED_DARKMODE_DESC" = "一部では正しく動作しない可能性があります。 この設定を変更したあとはアプリを再起動してください。";
+"OLED_DARKMODE_DESC" = "一部では正しく動作しない可能性があります。この設定を変更したあとはアプリの再起動が必要です。";
 
 "OLED_KEYBOARD" = "有機ELキーボード (実験的機能)";
-"OLED_KEYBOARD_DESC" = "一部では正しく動作しない可能性があります。 この設定を変更したあとはアプリを再起動してください。";
+"OLED_KEYBOARD_DESC" = "一部では正しく動作しない可能性があります。この設定を変更したあとはアプリの再起動が必要です。";
 
-"HIDE_PAID_PROMOTION_CARDS" = "「プロモーションを含む」 のバナーを非表示";
-"HIDE_PAID_PROMOTION_CARDS_DESC" = "一部の動画にある「プロモーションを含む」 のバナーを非表示にします。";
+"HIDE_PAID_PROMOTION_CARDS" = "プロモーションバナーを非表示";
+"HIDE_PAID_PROMOTION_CARDS_DESC" = "一部の動画にある「プロモーションを含みます」のバナーを非表示にします。";
 
 // YTCastConfirm
 "CASTING" = "キャスト";
-"MSG_ARE_YOU_SURE" = "本当にキャストを開始しますか?";
+"MSG_ARE_YOU_SURE" = "本当にキャストを開始しますか？";
 "MSG_YES" = "はい";
 "MSG_CANCEL" = "キャンセル";


### PR DESCRIPTION
The correct Japanese translation of the "Explore" tab is "探索".
Other translation optimizations were made.