### PR TITLE
Block update dialog

### DIFF
--- a/uYouPlus.xm
+++ b/uYouPlus.xm
@@ -139,6 +139,11 @@ BOOL hidePaidPromotionCard() {
 }
 %end
 
+// Block Update Dialog: https://github.com/PoomSmart/YouTubeHeader/blob/main/YTGlobalConfig.h
+%hook YTGlobalConfig
+- (BOOL)shouldBlockUpgradeDialog { return YES;}
+%end
+
 // YTAutoFullScreen: https://github.com/PoomSmart/YTAutoFullScreen/
 %hook YTPlayerViewController
 - (void)loadWithPlayerTransition:(id)arg1 playbackConfig:(id)arg2 {


### PR DESCRIPTION
Shoutout to Okemo#1950 for the help on finding the method for it.
This prevents YouTube/Google to not show the update screen, which means you can use uYouPlus/CercubePlus peacefully without Google ruining the fun.