### PR TITLE
Actually remove uYou download button in playlists

### DIFF
--- a/uYouPlus.xm
+++ b/uYouPlus.xm
@@ -218,9 +218,14 @@ static BOOL didFinishLaunching;
 // Remove uYou download button in playlists
 // https://github.com/qnblackcat/uYouPlus/issues/798#issuecomment-1364853420
 %hook YTPlaylistHeaderViewController
+- (void)setDownloadsButton:(id)arg {
+    UIButton *button = arg;
+    button.hidden = YES;
+    %orig(button);
+}
 - (id)downloadsButton {
-    UIView *button = %orig;
-    button.hidden = true;
+    UIButton *button = %orig;
+    button.hidden = YES;
     return button;
 }
 %end
@@ -1284,6 +1289,9 @@ UIColor* raisedColor = [UIColor colorWithRed:0.035 green:0.035 blue:0.035 alpha:
 
 # pragma mark - ctor
 %ctor {
+    // Load uYou first so its functions are available for hooks.
+    dlopen([[NSString stringWithFormat:@"%@/Frameworks/uYou.dylib", [[NSBundle mainBundle] bundlePath]] UTF8String], RTLD_LAZY);
+
     %init;
     if (@available(iOS 16, *)) {
        %init(iOS16);


### PR DESCRIPTION
Previous attempt to remove the button didn't work: https://github.com/qnblackcat/uYouPlus/pull/801#issuecomment-1365700214