### PR TITLE
Fix on Building with buildapp.yml

### DIFF
--- a/.github/workflows/buildapp.yml
+++ b/.github/workflows/buildapp.yml
@@ -8,7 +8,7 @@ on:
     inputs:
       uyou_version:
         description: "The version of uYou"
-        default: "2.1"
+        default: "2.3~1"
         required: true
         type: string
       decrypted_youtube_url:
@@ -100,9 +100,9 @@ jobs:
       - name: Download uYou & Prepare YouTube iPA
         run: |
           curl "https://raw.githubusercontent.com/Muirey03/RemoteLog/master/RemoteLog.h" --output "$THEOS/include/RemoteLog.h"
-          curl "https://miro92.com/repo/debs/com.miro.uyou_${{ env.UYOU_VERSION }}_iphoneos-arm.deb" --output "main/Tweaks/uYou/com.miro.uyou_${{ env.UYOU_VERSION }}_iphoneos-arm.deb"
+          curl "https://miro92.com/repo/debs/com.miro.uyou_${{ env.UYOU_VERSION }}_iphoneos-arm.deb" --output "main/Tweaks/uYou/com.miro.uyou_iphoneos-arm.deb"
           wget "$YOUTUBE_URL" --no-verbose -O main/YouTube.ipa
-          dpkg-deb -x "main/Tweaks/uYou/com.miro.uyou_${{ env.UYOU_VERSION }}_iphoneos-arm.deb" main/Tweaks/uYou/
+          dpkg-deb -x "main/Tweaks/uYou/com.miro.uyou_iphoneos-arm.deb" main/Tweaks/uYou/
           unzip -q main/YouTube.ipa -d main/tmp
           rm -rf main/tmp/Payload/YouTube.app/PlugIns/*
           cp -R main/Extensions/*.appex main/tmp/Payload/YouTube.app/PlugIns


### PR DESCRIPTION
Fixed an error that occurs when the version name contains special characters.
`2.3~1` contains `~`.