### PR TITLE
DontEatMyContent – Increase gap between display cutout and video

### DIFF
--- a/uYouPlus.xm
+++ b/uYouPlus.xm
@@ -607,7 +607,7 @@ static NSLayoutConstraint *widthConstraint, *heightConstraint, *centerXConstrain
     renderingView = [playerView renderingView];
 
     // Making renderingView a bit larger since constraining to safe area leaves a gap between the notch and video
-    CGFloat constant = 24.5; // Tested on iPhone 13 mini
+    CGFloat constant = 22.0; // Tested on iPhone 13 mini & 14 Pro Max
 
     widthConstraint = [renderingView.widthAnchor constraintEqualToAnchor:renderingViewContainer.safeAreaLayoutGuide.widthAnchor constant:constant];
     heightConstraint = [renderingView.heightAnchor constraintEqualToAnchor:renderingViewContainer.safeAreaLayoutGuide.heightAnchor constant:constant];


### PR DESCRIPTION
Dynamic Island was still cutting into videos; hopefully this will help