### PR TITLE
hide iSponsorBlock Button [Feature Request]

### DIFF
--- a/Header.h
+++ b/Header.h
@@ -1,5 +1,6 @@
 #import "Tweaks/YouTubeHeader/YTAppDelegate.h"
 #import "Tweaks/YouTubeHeader/YTPlayerViewController.h"
+#import "Tweaks/YouTubeHeader/YTQTMButton.h"
 
 #define LOC(x) [tweakBundle localizedStringForKey:x value:nil table:nil]
 #define YT_BUNDLE_ID @"com.google.ios.youtube"
@@ -50,6 +51,10 @@
 
 @interface YTPlaylistHeaderViewController: UIViewController
 @property UIButton *downloadsButton;
+@end
+
+@interface YTRightNavigationButtons : UIView
+@property YTQTMButton *sponsorBlockButton;
 @end
 
 // DontEatMyContent

--- a/Settings.xm
+++ b/Settings.xm
@@ -404,6 +404,17 @@ extern NSBundle *uYouPlusBundle();
                 }
                 settingItemId:0],
 
+
+            [YTSettingsSectionItemClass switchItemWithTitle:LOC(@"HIDE_SPONSORBLOCK_BUTTON")
+                titleDescription:LOC(@"HIDE_SPONSORBLOCK_BUTTON_DESC")
+                accessibilityIdentifier:nil
+                switchOn:IsEnabled(@"hideSponsorBlockButton_enabled")
+                switchBlock:^BOOL (YTSettingsCell *cell, BOOL enabled) {
+                    [[NSUserDefaults standardUserDefaults] setBool:enabled forKey:@"hideSponsorBlockButton_enabled"];
+                    return YES;
+                }
+                settingItemId:0],
+
             [YTSettingsSectionItemClass switchItemWithTitle:LOC(@"HIDE_CHIP_BAR")
                 titleDescription:LOC(@"HIDE_CHIP_BAR_DESC")
                 accessibilityIdentifier:nil

--- a/lang/uYouPlus.bundle/ar.lproj/Localizable.strings
+++ b/lang/uYouPlus.bundle/ar.lproj/Localizable.strings
@@ -115,8 +115,8 @@
 "ENABLE_YT_STARTUP_ANIMATION" = "Enable YouTube startup animation";
 "ENABLE_YT_STARTUP_ANIMATION_DESC" = "";
 
-"FIX_GOOGLE_SIGNIN" = "إصلاح تسجيل الدخول بحساب جوجل (لمستخدمي TrollStore فقط)";
-"FIX_GOOGLE_SIGNIN_DESC" = "هذا الخيار لا يعمل إلا إذا كان التطبيق مثبت بواسطة TrollStore: فعل هذا الخيار لتتمكن من تسجيل الدخول بحساب جوجل. يتطلب إعادة تشغيل التطبيق.";
+"HIDE_SPONSORBLOCK_BUTTON" = "Hide iSponsorBlock button";
+"HIDE_SPONSORBLOCK_BUTTON_DESC" = "Hide the iSponsorBlock button in the Nav Bar. App restart is required.";
 
 "HIDE_CHIP_BAR" = "Hide the Upper bar";
 "HIDE_CHIP_BAR_DESC" = "Hide Upper bar in the Home feeds (Trends, Music, Gaming...) and Subcription feeds (All videos, Continue watching...). App restart is required.";

--- a/lang/uYouPlus.bundle/cz.lproj/Localizable.strings
+++ b/lang/uYouPlus.bundle/cz.lproj/Localizable.strings
@@ -115,8 +115,8 @@
 "ENABLE_YT_STARTUP_ANIMATION" = "Enable YouTube startup animation";
 "ENABLE_YT_STARTUP_ANIMATION_DESC" = "";
 
-"FIX_GOOGLE_SIGNIN" = "Opravit přihlášení přes Google (pouze pro uživatele TrollStore)";
-"FIX_GOOGLE_SIGNIN_DESC" = "Tuto možnost zapněte pouze v případě, že se nemůžete přihlásit pomocí svého účtu Google a aplikace byla nainstalována prostřednictvím TrollStore. Pokud se můžete normálně přihlásit, ponechte ji deaktivovanou. Je vyžadován restart aplikace.";
+"HIDE_SPONSORBLOCK_BUTTON" = "Hide iSponsorBlock button";
+"HIDE_SPONSORBLOCK_BUTTON_DESC" = "Hide the iSponsorBlock button in the Nav Bar. App restart is required.";
 
 "HIDE_CHIP_BAR" = "Hide the Upper bar";
 "HIDE_CHIP_BAR_DESC" = "Hide Upper bar in the Home feeds (Trends, Music, Gaming...) and Subcription feeds (All videos, Continue watching...). App restart is required.";

--- a/lang/uYouPlus.bundle/de.lproj/Localizable.strings
+++ b/lang/uYouPlus.bundle/de.lproj/Localizable.strings
@@ -115,8 +115,8 @@
 "ENABLE_YT_STARTUP_ANIMATION" = "Enable YouTube startup animation";
 "ENABLE_YT_STARTUP_ANIMATION_DESC" = "";
 
-"FIX_GOOGLE_SIGNIN" = "Google-Anmeldung reparieren (nur für TrollStore-Benutzer!)";
-"FIX_GOOGLE_SIGNIN_DESC" = "Aktiviere diese Option nur, wenn Sie sich nicht mit Ihrem Google-Account anmelden können und die App über TrollStore installiert wurde. Wenn Sie sich normal anmelden können, halte diese Option deaktiviert! App-Neustart erforderlich!";
+"HIDE_SPONSORBLOCK_BUTTON" = "Hide iSponsorBlock button";
+"HIDE_SPONSORBLOCK_BUTTON_DESC" = "Hide the iSponsorBlock button in the Nav Bar. App restart is required.";
 
 "HIDE_CHIP_BAR" = "Obere Leiste ausblenden";
 "HIDE_CHIP_BAR_DESC" = "Obere Leiste in den Home-Feeds (Trends, Musik, Spiele...) und Abo-Feeds (Alle Videos, Weiterschauen...) ausblenden. App-Neustart erforderlich.";

--- a/lang/uYouPlus.bundle/el.lproj/Localizable.strings
+++ b/lang/uYouPlus.bundle/el.lproj/Localizable.strings
@@ -115,8 +115,8 @@
 "ENABLE_YT_STARTUP_ANIMATION" = "Enable YouTube startup animation";
 "ENABLE_YT_STARTUP_ANIMATION_DESC" = "";
 
-"FIX_GOOGLE_SIGNIN" = "Διόρθωση σύνδεσης Google (μόνο για χρήστες του TrollStore)";
-"FIX_GOOGLE_SIGNIN_DESC" = "Ενεργοποιήστε αυτήν την επιλογή μόνο όταν δεν μπορείτε να συνδεθείτε με τον λογαριασμό σας Google και η εφαρμογή έχει εγκατασταθεί μέσω του TrollStore. Εάν μπορείτε να συνδεθείτε κανονικά, διατηρήστε την απενεργοποιημένη. Απαιτείται επανεκκίνηση της εφαρμογής.";
+"HIDE_SPONSORBLOCK_BUTTON" = "Hide iSponsorBlock button";
+"HIDE_SPONSORBLOCK_BUTTON_DESC" = "Hide the iSponsorBlock button in the Nav Bar. App restart is required.";
 
 "HIDE_CHIP_BAR" = "Hide the Upper bar";
 "HIDE_CHIP_BAR_DESC" = "Hide Upper bar in the Home feeds (Trends, Music, Gaming...) and Subcription feeds (All videos, Continue watching...). App restart is required.";

--- a/lang/uYouPlus.bundle/en.lproj/Localizable.strings
+++ b/lang/uYouPlus.bundle/en.lproj/Localizable.strings
@@ -115,8 +115,8 @@
 "ENABLE_YT_STARTUP_ANIMATION" = "Enable YouTube startup animation";
 "ENABLE_YT_STARTUP_ANIMATION_DESC" = "";
 
-"FIX_GOOGLE_SIGNIN" = "Fix Google Sign in (for TrollStore user only)";
-"FIX_GOOGLE_SIGNIN_DESC" = "Only turn on this option when you can't sign in with your Google account and the app was installed via TrollStore. If you can log in normally, keep it disabled. App restart is required.";
+"HIDE_SPONSORBLOCK_BUTTON" = "Hide iSponsorBlock button";
+"HIDE_SPONSORBLOCK_BUTTON_DESC" = "Hide the iSponsorBlock button in the Nav Bar. App restart is required.";
 
 "HIDE_CHIP_BAR" = "Hide the Upper bar";
 "HIDE_CHIP_BAR_DESC" = "Hide Upper bar in the Home feeds (Trends, Music, Gaming...) and Subscription feeds (All videos, Continue watching...).";

--- a/lang/uYouPlus.bundle/es.lproj/Localizable.strings
+++ b/lang/uYouPlus.bundle/es.lproj/Localizable.strings
@@ -115,8 +115,8 @@
 "ENABLE_YT_STARTUP_ANIMATION" = "Activar la animación de inicio de YouTube";
 "ENABLE_YT_STARTUP_ANIMATION_DESC" = "";
 
-"FIX_GOOGLE_SIGNIN" = "Reparar el inicio de sesión de Google (solo para usuarios de TrollStore)";
-"FIX_GOOGLE_SIGNIN_DESC" = "Active esta opción solo cuando no pueda iniciar sesión con su cuenta de Google y la aplicación se instaló a través de TrollStore. Si puede iniciar sesión normalmente, manténgala desactivada. Es necesario reiniciar la aplicación.";
+"HIDE_SPONSORBLOCK_BUTTON" = "Hide iSponsorBlock button";
+"HIDE_SPONSORBLOCK_BUTTON_DESC" = "Hide the iSponsorBlock button in the Nav Bar. App restart is required.";
 
 "HIDE_CHIP_BAR" = "Ocultar la barra superior";
 "HIDE_CHIP_BAR_DESC" = "Ocultar la barra superior de las fuentes de inicio (Tendencias, Música, Juegos...) y de suscripción (Todos los vídeos, Seguir viendo...). Es necesario reiniciar la aplicación.";

--- a/lang/uYouPlus.bundle/fr.lproj/Localizable.strings
+++ b/lang/uYouPlus.bundle/fr.lproj/Localizable.strings
@@ -115,8 +115,8 @@
 "ENABLE_YT_STARTUP_ANIMATION" = "Enable YouTube startup animation";
 "ENABLE_YT_STARTUP_ANIMATION_DESC" = "";
 
-"FIX_GOOGLE_SIGNIN" = "Réparer l'identification Google (pour les utilisateurs de TrollStore uniquement)";
-"FIX_GOOGLE_SIGNIN_DESC" = "Activez cette option uniquement si vous ne pouvez pas vous connecter avec votre compte Google et que l'application a été installée via TrollStore. Si vous pouvez vous connecter normalement, laissez-la désactivée. Un redémarrage de l'application est nécessaire.";
+"HIDE_SPONSORBLOCK_BUTTON" = "Hide iSponsorBlock button";
+"HIDE_SPONSORBLOCK_BUTTON_DESC" = "Hide the iSponsorBlock button in the Nav Bar. App restart is required.";
 
 "HIDE_CHIP_BAR" = "Masquer la barre supérieure";
 "HIDE_CHIP_BAR_DESC" = "Masquer la barre supérieure dans les fils d'actualité (Tendances, Musique, Gaming...) et les fils d'abonnement (Toutes les vidéos, Poursuivre la lecture...). Un redémarrage de l'application est nécessaire.";

--- a/lang/uYouPlus.bundle/he.lproj/Localizable.strings
+++ b/lang/uYouPlus.bundle/he.lproj/Localizable.strings
@@ -115,8 +115,8 @@
 "ENABLE_YT_STARTUP_ANIMATION" = "Enable YouTube startup animation";
 "ENABLE_YT_STARTUP_ANIMATION_DESC" = "";
 
-"FIX_GOOGLE_SIGNIN" = "תקן כניסה של Google (עבור משתמש TrollStore בלבד)";
-"FIX_GOOGLE_SIGNIN_DESC" = "הפעל אפשרות זו רק כאשר אינך יכול להיכנס עם חשבון Google שלך והאפליקציה הותקנה דרך TrollStore. אם אתה יכול להתחבר כרגיל, השאר אותה מושבתת. נדרשת הפעלה מחדש של האפליקציה.";
+"HIDE_SPONSORBLOCK_BUTTON" = "Hide iSponsorBlock button";
+"HIDE_SPONSORBLOCK_BUTTON_DESC" = "Hide the iSponsorBlock button in the Nav Bar. App restart is required.";
 
 "HIDE_CHIP_BAR" = "Hide the Upper bar";
 "HIDE_CHIP_BAR_DESC" = "Hide Upper bar in the Home feeds (Trends, Music, Gaming...) and Subcription feeds (All videos, Continue watching...). App restart is required.";

--- a/lang/uYouPlus.bundle/hu.lproj/Localizable.strings
+++ b/lang/uYouPlus.bundle/hu.lproj/Localizable.strings
@@ -115,8 +115,8 @@
 "ENABLE_YT_STARTUP_ANIMATION" = "Enable YouTube startup animation";
 "ENABLE_YT_STARTUP_ANIMATION_DESC" = "";
 
-"FIX_GOOGLE_SIGNIN" = "A Google bejelentkezés javítása (csak a TrollStore-felhasználók számára)";
-"FIX_GOOGLE_SIGNIN_DESC" = "Csak akkor kapcsolja be ezt az opciót, ha nem tud bejelentkezni Google-fiókjával, és az alkalmazást a TrollStore-on keresztül telepítették. Ha normálisan be tud jelentkezni, tartsa letiltva. Az alkalmazás újraindítása szükséges.";
+"HIDE_SPONSORBLOCK_BUTTON" = "Hide iSponsorBlock button";
+"HIDE_SPONSORBLOCK_BUTTON_DESC" = "Hide the iSponsorBlock button in the Nav Bar. App restart is required.";
 
 "HIDE_CHIP_BAR" = "Hide the Upper bar";
 "HIDE_CHIP_BAR_DESC" = "Hide Upper bar in the Home feeds (Trends, Music, Gaming...) and Subcription feeds (All videos, Continue watching...). App restart is required.";

--- a/lang/uYouPlus.bundle/it.lproj/Localizable.strings
+++ b/lang/uYouPlus.bundle/it.lproj/Localizable.strings
@@ -115,8 +115,8 @@
 "ENABLE_YT_STARTUP_ANIMATION" = "Abilita YouTube startup animazione";
 "ENABLE_YT_STARTUP_ANIMATION_DESC" = "";
 
-"FIX_GOOGLE_SIGNIN" = "Ripara Google Sign in (solo per utenti TrollStore)";
-"FIX_GOOGLE_SIGNIN_DESC" = "Attiva questa opzione solo quando non puoi accedere al tuo account Google e l'app è stata installata attraverso TrollStore. Se puoi accedere normalmente, tienila disabilitata. È richiesto un riavvio dell'app.";
+"HIDE_SPONSORBLOCK_BUTTON" = "Hide iSponsorBlock button";
+"HIDE_SPONSORBLOCK_BUTTON_DESC" = "Hide the iSponsorBlock button in the Nav Bar. App restart is required.";
 
 "HIDE_CHIP_BAR" = "Nascondi la barra superiore";
 "HIDE_CHIP_BAR_DESC" = "Nascondi la barra superiore nella Home (Tendenze, Musica, Giochi...) e Iscrizioni (Tutti i video, Continua a guardare...). È richiesto il riavvio dell'app.";

--- a/lang/uYouPlus.bundle/ja.lproj/Localizable.strings
+++ b/lang/uYouPlus.bundle/ja.lproj/Localizable.strings
@@ -115,8 +115,8 @@
 "ENABLE_YT_STARTUP_ANIMATION" = "Enable YouTube startup animation";
 "ENABLE_YT_STARTUP_ANIMATION_DESC" = "";
 
-"FIX_GOOGLE_SIGNIN" = "Googleのサインインを修正 (TrollStoreユーザーのみ)";
-"FIX_GOOGLE_SIGNIN_DESC" = "アプリがTrollStoreでインストールされた場合のみ機能します。このオプションを有効にしてGoogleアカウントでサインインできるようにします。アプリの再起動が必要です。";
+"HIDE_SPONSORBLOCK_BUTTON" = "Hide iSponsorBlock button";
+"HIDE_SPONSORBLOCK_BUTTON_DESC" = "Hide the iSponsorBlock button in the Nav Bar. App restart is required.";
 
 "HIDE_CHIP_BAR" = "トップバーを非表示";
 "HIDE_CHIP_BAR_DESC" = "ホーム(トレンド,音楽,ゲーム...)とサブスクリプション(すべてのビデオ、視聴を続ける...)リボンのトップバーを非表示にします。アプリの再起動が必要です。";

--- a/lang/uYouPlus.bundle/ko.lproj/Localizable.strings
+++ b/lang/uYouPlus.bundle/ko.lproj/Localizable.strings
@@ -115,8 +115,8 @@
 "ENABLE_YT_STARTUP_ANIMATION" = "Enable YouTube startup animation";
 "ENABLE_YT_STARTUP_ANIMATION_DESC" = "";
 
-"FIX_GOOGLE_SIGNIN" = "구글 로그인 문제 수정 (TrollStore 사용자만 해당)";
-"FIX_GOOGLE_SIGNIN_DESC" = "TrollStore를 통해 설치된 앱에만 적용됩니다: 구글 계정으로 로그인하려면 이 설정을 켜 주세요. 앱을 다시 시작해야 합니다.";
+"HIDE_SPONSORBLOCK_BUTTON" = "Hide iSponsorBlock button";
+"HIDE_SPONSORBLOCK_BUTTON_DESC" = "Hide the iSponsorBlock button in the Nav Bar. App restart is required.";
 
 "HIDE_CHIP_BAR" = "피드 선택 막대 숨기기";
 "HIDE_CHIP_BAR_DESC" = "앱의 홈 화면에서 맞춤 동영상(인기 급상승, 음악, 게임...)과 구독 피드(전체, 감상한 동영상...) 선택 막대를 숨깁니다. 앱을 다시 시작해야 합니다.";

--- a/lang/uYouPlus.bundle/nl.lproj/Localizable.strings
+++ b/lang/uYouPlus.bundle/nl.lproj/Localizable.strings
@@ -115,8 +115,8 @@
 "ENABLE_YT_STARTUP_ANIMATION" = "Enable YouTube startup animation";
 "ENABLE_YT_STARTUP_ANIMATION_DESC" = "";
 
-"FIX_GOOGLE_SIGNIN" = "Fix Inloggen met Google (Alleen voor TrollStore gebruikers)";
-"FIX_GOOGLE_SIGNIN_DESC" = "Zet dit aan wanneer je niet kan inloggen met je Google account en je de app hebt geïnstalleerd met Trollstore. Als je in kan loggen laat dit dan met rust. Om dit te activeren moet je de app opnieuw opstarten.";
+"HIDE_SPONSORBLOCK_BUTTON" = "Hide iSponsorBlock button";
+"HIDE_SPONSORBLOCK_BUTTON_DESC" = "Hide the iSponsorBlock button in the Nav Bar. App restart is required.";
 
 "HIDE_CHIP_BAR" = "Hide the Upper bar";
 "HIDE_CHIP_BAR_DESC" = "Hide Upper bar in the Home feeds (Trends, Music, Gaming...) and Subcription feeds (All videos, Continue watching...). App restart is required.";

--- a/lang/uYouPlus.bundle/pl.lproj/Localizable.strings
+++ b/lang/uYouPlus.bundle/pl.lproj/Localizable.strings
@@ -115,8 +115,8 @@
 "ENABLE_YT_STARTUP_ANIMATION" = "Enable YouTube startup animation";
 "ENABLE_YT_STARTUP_ANIMATION_DESC" = "";
 
-"FIX_GOOGLE_SIGNIN" = "Napraw logowanie się z Google (tylko dla użytkowników TrollStore)";
-"FIX_GOOGLE_SIGNIN_DESC" = "Włącz tą opcję tylko wtedy, kiedy nie możesz zalogować się swoim kontem Google, a aplikacja została zainstalowana przez TrollStore. Jeżeli da się zalogować normalnie, zostaw to wyłączone. Restart aplikacji jest wymagany.";
+"HIDE_SPONSORBLOCK_BUTTON" = "Hide iSponsorBlock button";
+"HIDE_SPONSORBLOCK_BUTTON_DESC" = "Hide the iSponsorBlock button in the Nav Bar. App restart is required.";
 
 "HIDE_CHIP_BAR" = "Hide the Upper bar";
 "HIDE_CHIP_BAR_DESC" = "Hide Upper bar in the Home feeds (Trends, Music, Gaming...) and Subcription feeds (All videos, Continue watching...). App restart is required.";

--- a/lang/uYouPlus.bundle/pt.lproj/Localizable.strings
+++ b/lang/uYouPlus.bundle/pt.lproj/Localizable.strings
@@ -115,8 +115,8 @@
 "HIDE_UYOU_SHORTS_DOWNLOAD_BUTTON" = "Hide uYou's buttons";
 "HIDE_UYOU_SHORTS_DOWNLOAD_BUTTON_DESC" = "Hide uYou's download buttons in Shorts.";
 
-"FIX_GOOGLE_SIGNIN" = "Corrigir o login do Google (somente para usuários da TrollStore)";
-"FIX_GOOGLE_SIGNIN_DESC" = "Ative esta opção somente quando você não conseguir fazer login com sua conta do Google e o aplicativo foi instalado via TrollStore. Se você conseguir fazer login normalmente, mantenha-o desativado. A reinicialização do app é necessária.";
+"HIDE_SPONSORBLOCK_BUTTON" = "Hide iSponsorBlock button";
+"HIDE_SPONSORBLOCK_BUTTON_DESC" = "Hide the iSponsorBlock button in the Nav Bar. App restart is required.";
 
 "HIDE_CHIP_BAR" = "Ocultar a Barra superior";
 "HIDE_CHIP_BAR_DESC" = "Oculta a Barra superior nos Feeds iniciais (Tendências, Música, Jogos...) e Feeds de inscrições (Todos os vídeos, Continuar assistindo...). A reinicialização do app é necessária.";

--- a/lang/uYouPlus.bundle/ro.lproj/Localizable.strings
+++ b/lang/uYouPlus.bundle/ro.lproj/Localizable.strings
@@ -115,8 +115,8 @@
 "HIDE_UYOU_SHORTS_DOWNLOAD_BUTTON" = "Hide uYou's buttons";
 "HIDE_UYOU_SHORTS_DOWNLOAD_BUTTON_DESC" = "Hide uYou's download buttons in Shorts.";
 
-"FIX_GOOGLE_SIGNIN" = "Rezolvare problemă autentificare cont Google (doar pentru utilizatorii TrollStore)";
-"FIX_GOOGLE_SIGNIN_DESC" = "Activează această opțiune doar în cazul în care nu te poți autentifica în contul tău Google și apariția a fost instalată via TrollStore. Dacă te poți autentifica fără probleme, țineți setarea dezactivată. Este necesară repornirea aplicației.";
+"HIDE_SPONSORBLOCK_BUTTON" = "Hide iSponsorBlock button";
+"HIDE_SPONSORBLOCK_BUTTON_DESC" = "Hide the iSponsorBlock button in the Nav Bar. App restart is required.";
 
 "HIDE_CHIP_BAR" = "Hide the Upper bar";
 "HIDE_CHIP_BAR_DESC" = "Hide Upper bar in the Home feeds (Trends, Music, Gaming...) and Subcription feeds (All videos, Continue watching...). App restart is required.";

--- a/lang/uYouPlus.bundle/ru.lproj/Localizable.strings
+++ b/lang/uYouPlus.bundle/ru.lproj/Localizable.strings
@@ -115,8 +115,8 @@
 "ENABLE_YT_STARTUP_ANIMATION" = "Включить анимацию запуска YouTube";
 "ENABLE_YT_STARTUP_ANIMATION_DESC" = "";
 
-"FIX_GOOGLE_SIGNIN" = "Исправить авторизацию (TrollStore)";
-"FIX_GOOGLE_SIGNIN_DESC" = "Включите данную опцию только, если не можете войти в учетную запись Google, а приложение установлено через TrollStore. Если удается авторизоваться как обычно, оставьте данную опцию отключенной. Потребуется перезагрузка.";
+"HIDE_SPONSORBLOCK_BUTTON" = "Hide iSponsorBlock button";
+"HIDE_SPONSORBLOCK_BUTTON_DESC" = "Hide the iSponsorBlock button in the Nav Bar. App restart is required.";
 
 "HIDE_CHIP_BAR" = "Скрыть верхнюю панель";
 "HIDE_CHIP_BAR_DESC" = "Скрывает верхнюю панель на вкладках «Главная» (Тренды, Музыка, Игры...) и «Подписки» (Все видео, Продолжить просмотр...)\nТребуется перезапуск приложения.";

--- a/lang/uYouPlus.bundle/template.lproj/Localizable.strings
+++ b/lang/uYouPlus.bundle/template.lproj/Localizable.strings
@@ -130,8 +130,8 @@ https://github.com/PoomSmart/Return-YouTube-Dislikes/tree/main/layout/Library/Ap
 "ENABLE_YT_STARTUP_ANIMATION" = "Enable YouTube startup animation";
 "ENABLE_YT_STARTUP_ANIMATION_DESC" = "";
 
-"FIX_GOOGLE_SIGNIN" = "Fix Google Sign in (for TrollStore user only)";
-"FIX_GOOGLE_SIGNIN_DESC" = "Only turn on this option when you can't sign in with your Google account and the app was installed via TrollStore. If you can log in normally, keep it disabled. App restart is required.";
+"HIDE_SPONSORBLOCK_BUTTON" = "Hide iSponsorBlock button";
+"HIDE_SPONSORBLOCK_BUTTON_DESC" = "Hide the iSponsorBlock button in the Nav Bar. App restart is required.";
 
 "HIDE_CHIP_BAR" = "Hide the Upper bar";
 "HIDE_CHIP_BAR_DESC" = "Hide Upper bar in the Home feeds (Trends, Music, Gaming...) and Subscription feeds (All videos, Continue watching...).";

--- a/lang/uYouPlus.bundle/tr.lproj/Localizable.strings
+++ b/lang/uYouPlus.bundle/tr.lproj/Localizable.strings
@@ -115,8 +115,8 @@
 "ENABLE_YT_STARTUP_ANIMATION" = "Enable YouTube startup animation";
 "ENABLE_YT_STARTUP_ANIMATION_DESC" = "";
 
-"FIX_GOOGLE_SIGNIN" = "Google Oturumu Açma'yı düzeltin (yalnızca TrollStore kullanıcıları için)";
-"FIX_GOOGLE_SIGNIN_DESC" = "Bu seçeneği yalnızca Google hesabınızla oturum açamadığınızda ve uygulama TrollStore aracılığıyla yüklendiyse açın. Normal olarak giriş yapabiliyorsanız, devre dışı bırakın. Uygulamanın yeniden başlatılması gerekir.";
+"HIDE_SPONSORBLOCK_BUTTON" = "Hide iSponsorBlock button";
+"HIDE_SPONSORBLOCK_BUTTON_DESC" = "Hide the iSponsorBlock button in the Nav Bar. App restart is required.";
 
 "HIDE_CHIP_BAR" = "Hide the Upper bar";
 "HIDE_CHIP_BAR_DESC" = "Hide Upper bar in the Home feeds (Trends, Music, Gaming...) and Subcription feeds (All videos, Continue watching...). App restart is required.";

--- a/lang/uYouPlus.bundle/vi.lproj/Localizable.strings
+++ b/lang/uYouPlus.bundle/vi.lproj/Localizable.strings
@@ -115,8 +115,8 @@
 "ENABLE_YT_STARTUP_ANIMATION" = "Bật hiệu ứng khi khởi động YouTube";
 "ENABLE_YT_STARTUP_ANIMATION_DESC" = "";
 
-"FIX_GOOGLE_SIGNIN" = "Sửa lỗi không thể đăng nhập tài khoản Google";
-"FIX_GOOGLE_SIGNIN_DESC" = "Chỉ bật tính năng này khi bạn không thể đăng nhập tài khoản Google và ứng dụng được cài qua TrollStore. Nếu bạn có thể đăng nhập bình thường thì hãy tắt tính năng này. Cần khởi động lại ứng dụng.";
+"HIDE_SPONSORBLOCK_BUTTON" = "Hide iSponsorBlock button";
+"HIDE_SPONSORBLOCK_BUTTON_DESC" = "Hide the iSponsorBlock button in the Nav Bar. App restart is required.";
 
 "HIDE_CHIP_BAR" = "Ẩn thanh phím tắt";
 "HIDE_CHIP_BAR_DESC" = "Ẩn thanh phím tắt trong Home feed (Thịnh hành, Âm nhạc, Trò chơi...) và trong Subciption feed (Tất cả, Tiếp tục xem...).";

--- a/lang/uYouPlus.bundle/zh_cn.lproj/Localizable.strings
+++ b/lang/uYouPlus.bundle/zh_cn.lproj/Localizable.strings
@@ -115,8 +115,8 @@
 "ENABLE_YT_STARTUP_ANIMATION" = "Enable YouTube startup animation";
 "ENABLE_YT_STARTUP_ANIMATION_DESC" = "";
 
-"FIX_GOOGLE_SIGNIN" = "修复 Google 账号登录问题（仅 TrollStore 用户有效）";
-"FIX_GOOGLE_SIGNIN_DESC" = "仅在使用 TrollStore 安装本 App 的情况下生效：启用本设置后即可正常登录您的 Google 账号。更改本设置后需要重启 App。";
+"HIDE_SPONSORBLOCK_BUTTON" = "Hide iSponsorBlock button";
+"HIDE_SPONSORBLOCK_BUTTON_DESC" = "Hide the iSponsorBlock button in the Nav Bar. App restart is required.";
 
 "HIDE_CHIP_BAR" = "隐藏顶部标签栏";
 "HIDE_CHIP_BAR_DESC" = "隐藏首页和订阅内容页顶部的标签栏（例如：首页顶部的“音乐”、“游戏”、“新闻”等以及订阅内容页顶部的“今天”、“继续观看”、“未观看”等）。更改本设置后需要重启 App。";

--- a/lang/uYouPlus.bundle/zh_tw.lproj/Localizable.strings
+++ b/lang/uYouPlus.bundle/zh_tw.lproj/Localizable.strings
@@ -115,8 +115,8 @@
 "ENABLE_YT_STARTUP_ANIMATION" = "Enable YouTube startup animation";
 "ENABLE_YT_STARTUP_ANIMATION_DESC" = "";
 
-"FIX_GOOGLE_SIGNIN" = "修復 Google 帳號登入問題（僅TrollStore 使用者有效）";
-"FIX_GOOGLE_SIGNIN_DESC" = "僅在使用 TrollStore 安裝此應用程式時有效：啟用本設定後即可正常登入 Google 帳號，需要重新啟動應用程式。";
+"HIDE_SPONSORBLOCK_BUTTON" = "Hide iSponsorBlock button";
+"HIDE_SPONSORBLOCK_BUTTON_DESC" = "Hide the iSponsorBlock button in the Nav Bar. App restart is required.";
 
 "HIDE_CHIP_BAR" = "Hide the Upper bar";
 "HIDE_CHIP_BAR_DESC" = "Hide Upper bar in the Home feeds (Trends, Music, Gaming...) and Subcription feeds (All videos, Continue watching...). App restart is required.";

--- a/uYouPlus.xm
+++ b/uYouPlus.xm
@@ -1301,6 +1301,15 @@ UIColor* raisedColor = [UIColor colorWithRed:0.035 green:0.035 blue:0.035 alpha:
 %end
 %end
 
+%hook YTRightNavigationButtons
+- (void)layoutSubviews {
+    %orig;
+    if (IsEnabled(@"hideSponsorBlockButton_enabled")) { 
+        self.sponsorBlockButton.hidden = YES;
+    }
+}
+%end
+
 // YT startup animation
 %hook YTColdConfig
 - (BOOL)mainAppCoreClientIosEnableStartupAnimation {


### PR DESCRIPTION
Back at it again. adding another feature just like I did for the iPhone Layout.
the ability to hide the iSponsorBlock Button in the Navigation Bar.

also I modified the strings and removed the strings related to google sign in just in case if you started planning on removing that.

This Pull Request was made because it’s been requested to be added to uYouPlus.
https://github.com/qnblackcat/uYouPlus/issues/915
https://github.com/qnblackcat/uYouPlus/issues/609
https://github.com/qnblackcat/uYouPlus/issues/461