### PR TITLE
Update buildapp.yml to fix error homebrew: dpkg: Failed to download resource "dpkg"

### DIFF
--- a/.github/workflows/buildapp.yml
+++ b/.github/workflows/buildapp.yml
@@ -55,6 +55,9 @@ jobs:
           path: main
           submodules: recursive
 
+      - name: Update Homebrew
+        run: brew update
+
       - name: Install Dependencies
         run: brew install ldid dpkg make
 


### PR DESCRIPTION
Update buildapp.yml to fix error homebrew: dpkg: Failed to download resource "dpkg". This error occurs because Homebrew has not yet obtained the latest Formulae, so resources may be deleted on the server that Homebrew may still point to that resource, creating 404 errors that do not exist. I have added a formulae update for homebrew before homebrew installed dependencies