### PR TITLE
iSponsorBlock crash workaround

### DIFF
--- a/Sources/uYouPlus.xm
+++ b/Sources/uYouPlus.xm
@@ -187,6 +187,13 @@ static BOOL findCell(ASNodeController *nodeController, NSArray <NSString *> *ide
 
 # pragma mark - Miscellaneous
 
+// Fix iSponsorBlock crash on iPhones with dynamic island(Spoof old YT version)
+%hook YTVersionUtils
++ (NSString *)appVersion {
+    return @"18.18.2";
+}
+%end
+
 // Hide iSponsorBlock
 %hook YTRightNavigationButtons
 - (void)didMoveToWindow {


### PR DESCRIPTION
Since latest YT versions enabled iSponsorBlock makes the app crash on iPhones with dynamic island when any video is started.
This will spoof the app version to 18.18.2 which apparently fixes the issue.

Original issue and solution:
https://github.com/Galactic-Dev/iSponsorBlock/issues/110#issuecomment-2023371040