### PR TITLE
Pin runner image to macos-12

### DIFF
--- a/.github/workflows/buildapp.yml
+++ b/.github/workflows/buildapp.yml
@@ -44,7 +44,7 @@ concurrency:
 jobs:
   build:
     name: Build uYouPlus
-    runs-on: macos-latest
+    runs-on: macos-12
     permissions:
       contents: write
 


### PR DESCRIPTION
Fixes #1429. 
GitHub recently updated the image `macos-latest` references.
Pin the image to macos-12 for now until the problems building with `macos-14` is sorted.

https://github.com/actions/runner-images/commit/da5ebb36223a06890092a423a0466b28ea2de595