### PR TITLE
Don't Publish Artifact By Default

### DIFF
--- a/.github/workflows/buildapp.yml
+++ b/.github/workflows/buildapp.yml
@@ -33,7 +33,7 @@ on:
         type: boolean
       upload_artifact:
         description: "Upload Artifact"
-        default: true
+        default: false
         required: false
         type: boolean
 


### PR DESCRIPTION
This will make it so that the .ipa isn't uploaded as a public available IPA. But instead a draft release will be the default and only option selected by default. 