### PR TITLE
Update build IPA workflow to not upload the IPA artifact by default

### DIFF
--- a/.github/workflows/buildapp.yml
+++ b/.github/workflows/buildapp.yml
@@ -33,7 +33,7 @@ on:
         type: boolean
       upload_artifact:
         description: "Upload Artifact"
-        default: true
+        default: false
         required: false
         type: boolean
 


### PR DESCRIPTION
This is simply to make it so that only "Draft Release" is checked by default. Saving a step do not uncheck "Upload Artifact" and to make sure that no IPA file gets uploaded accidentally to the public, even if the repository is a forked one. 