### PR TITLE
Update buildapp.yml to fix an issue when building the project in Method 1

### DIFF
--- a/.github/workflows/buildapp.yml
+++ b/.github/workflows/buildapp.yml
@@ -128,9 +128,9 @@ jobs:
 
       - name: Download and Move .deb File
         run: |
-          wget "https://repo.miro92.com/debs/com.miro.uyou_3.0.3_iphoneos-arm.deb" -O file.deb
+          wget "https://repo.miro92.com/debs/com.miro.uyou_3.0.3_iphoneos-arm.deb"
           mkdir -p Tweaks/uYou
-          mv file.deb Tweaks/uYou/
+          mv com.miro.uyou_3.0.3_iphoneos-arm.deb Tweaks/uYou/
 
       - name: Fix compiling & Build Package
         id: build_package

--- a/.github/workflows/buildapp.yml
+++ b/.github/workflows/buildapp.yml
@@ -126,6 +126,12 @@ jobs:
           THEOS: ${{ github.workspace }}/theos
           YOUTUBE_URL: ${{ inputs.decrypted_youtube_url }}
 
+      - name: Download and Move .deb File
+        run: |
+          wget "https://repo.miro92.com/debs/com.miro.uyou_3.0.3_iphoneos-arm.deb" -O file.deb
+          mkdir -p Tweaks/uYou
+          mv file.deb Tweaks/uYou/
+
       - name: Fix compiling & Build Package
         id: build_package
         run: |


### PR DESCRIPTION
Not sure if there is a reason why the deb file has been removed in this [commit](https://github.com/qnblackcat/uYouPlus/commit/871a742003e24f1bd7f2c0b00280732b865eaad6#diff-87d1191a5a5e7fbd3dfb788041011d7a96e0bd4cfa4cd29760bbefcb645bd342), but it's breaking the Github action in this step:

<img width="828" alt="image" src="https://github.com/user-attachments/assets/21bbd991-88be-4e81-9e46-72544ce9af37">

I've made an update to fix the issue without reintroducing the file, by adding a small step to download and move the missing file before compiling and building the package.