### PR TITLE
Replace YouTube's download with uYou + other minor improvements

### DIFF
--- a/Localizations/uYouPlus.bundle/ar.lproj/Localizable.strings
+++ b/Localizations/uYouPlus.bundle/ar.lproj/Localizable.strings
@@ -66,6 +66,9 @@
 "STOCK_VOLUME_HUD" = "استخدام مؤشر تغيير الصوت الخاص بالنظام";
 "STOCK_VOLUME_HUD_DESC" = "إظهار مؤشر تغيير الصوت الرسمي الخاص بـ iOS بدلاً من مؤشر يوتيوب";
 
+"REPLACE_YT_DOWNLOAD_WITH_UYOU" = "Replace YouTube's download with uYou's";
+"REPLACE_YT_DOWNLOAD_WITH_UYOU_DESC" = "";
+
 // Video controls overlay options
 "VIDEO_CONTROLS_OVERLAY_OPTIONS" = "📹 أزرار التحكم على الطبقة فوق الفيديو";
 

--- a/Localizations/uYouPlus.bundle/cz.lproj/Localizable.strings
+++ b/Localizations/uYouPlus.bundle/cz.lproj/Localizable.strings
@@ -66,6 +66,9 @@
 "STOCK_VOLUME_HUD" = "Use stock iOS volume HUD";
 "STOCK_VOLUME_HUD_DESC" = "";
 
+"REPLACE_YT_DOWNLOAD_WITH_UYOU" = "Replace YouTube's download with uYou's";
+"REPLACE_YT_DOWNLOAD_WITH_UYOU_DESC" = "";
+
 // Video controls overlay options
 "VIDEO_CONTROLS_OVERLAY_OPTIONS" = "📹 Video Controls Overlay Options";
 

--- a/Localizations/uYouPlus.bundle/de.lproj/Localizable.strings
+++ b/Localizations/uYouPlus.bundle/de.lproj/Localizable.strings
@@ -66,6 +66,9 @@
 "STOCK_VOLUME_HUD" = "Standard iOS Lautstärke HUD aktivieren";
 "STOCK_VOLUME_HUD_DESC" = "";
 
+"REPLACE_YT_DOWNLOAD_WITH_UYOU" = "Replace YouTube's download with uYou's";
+"REPLACE_YT_DOWNLOAD_WITH_UYOU_DESC" = "";
+
 // Video controls overlay options
 "VIDEO_CONTROLS_OVERLAY_OPTIONS" = "📹 Video Controls Overlay Optionen";
 

--- a/Localizations/uYouPlus.bundle/el.lproj/Localizable.strings
+++ b/Localizations/uYouPlus.bundle/el.lproj/Localizable.strings
@@ -66,6 +66,9 @@
 "STOCK_VOLUME_HUD" = "Use stock iOS volume HUD";
 "STOCK_VOLUME_HUD_DESC" = "";
 
+"REPLACE_YT_DOWNLOAD_WITH_UYOU" = "Replace YouTube's download with uYou's";
+"REPLACE_YT_DOWNLOAD_WITH_UYOU_DESC" = "";
+
 // Video controls overlay options
 "VIDEO_CONTROLS_OVERLAY_OPTIONS" = "📹 Video controls overlay options";
 

--- a/Localizations/uYouPlus.bundle/en.lproj/Localizable.strings
+++ b/Localizations/uYouPlus.bundle/en.lproj/Localizable.strings
@@ -66,6 +66,9 @@
 "STOCK_VOLUME_HUD" = "Use stock iOS volume HUD";
 "STOCK_VOLUME_HUD_DESC" = "";
 
+"REPLACE_YT_DOWNLOAD_WITH_UYOU" = "Replace YouTube's download with uYou's";
+"REPLACE_YT_DOWNLOAD_WITH_UYOU_DESC" = "";
+
 // Video controls overlay options
 "VIDEO_CONTROLS_OVERLAY_OPTIONS" = "📹 Video controls overlay options";
 

--- a/Localizations/uYouPlus.bundle/es.lproj/Localizable.strings
+++ b/Localizations/uYouPlus.bundle/es.lproj/Localizable.strings
@@ -66,6 +66,9 @@
 "STOCK_VOLUME_HUD" = "Utiliza el HUD de volumen de iOS";
 "STOCK_VOLUME_HUD_DESC" = "";
 
+"REPLACE_YT_DOWNLOAD_WITH_UYOU" = "Replace YouTube's download with uYou's";
+"REPLACE_YT_DOWNLOAD_WITH_UYOU_DESC" = "";
+
 // Video controls overlay options
 "VIDEO_CONTROLS_OVERLAY_OPTIONS" = "📹 Opciones de superposición de controles de vídeo";
 

--- a/Localizations/uYouPlus.bundle/fr.lproj/Localizable.strings
+++ b/Localizations/uYouPlus.bundle/fr.lproj/Localizable.strings
@@ -66,6 +66,9 @@
 "STOCK_VOLUME_HUD" = "Utiliser l'affichage iOS du volume par défaut";
 "STOCK_VOLUME_HUD_DESC" = "";
 
+"REPLACE_YT_DOWNLOAD_WITH_UYOU" = "Replace YouTube's download with uYou's";
+"REPLACE_YT_DOWNLOAD_WITH_UYOU_DESC" = "";
+
 // Video controls overlay options
 "VIDEO_CONTROLS_OVERLAY_OPTIONS" = "📹 Options de superposition des contrôles vidéo";
 

--- a/Localizations/uYouPlus.bundle/he.lproj/Localizable.strings
+++ b/Localizations/uYouPlus.bundle/he.lproj/Localizable.strings
@@ -66,6 +66,9 @@
 "STOCK_VOLUME_HUD" = "Use stock iOS volume HUD";
 "STOCK_VOLUME_HUD_DESC" = "";
 
+"REPLACE_YT_DOWNLOAD_WITH_UYOU" = "Replace YouTube's download with uYou's";
+"REPLACE_YT_DOWNLOAD_WITH_UYOU_DESC" = "";
+
 // Video controls overlay options
 "VIDEO_CONTROLS_OVERLAY_OPTIONS" = "📹 Video controls overlay options";
 

--- a/Localizations/uYouPlus.bundle/hu.lproj/Localizable.strings
+++ b/Localizations/uYouPlus.bundle/hu.lproj/Localizable.strings
@@ -66,6 +66,9 @@
 "STOCK_VOLUME_HUD" = "Use iOS stock volume HUD";
 "STOCK_VOLUME_HUD_DESC" = "";
 
+"REPLACE_YT_DOWNLOAD_WITH_UYOU" = "Replace YouTube's download with uYou's";
+"REPLACE_YT_DOWNLOAD_WITH_UYOU_DESC" = "";
+
 // Video controls overlay options
 "VIDEO_CONTROLS_OVERLAY_OPTIONS" = "📹 Video controls overlay options";
 

--- a/Localizations/uYouPlus.bundle/it.lproj/Localizable.strings
+++ b/Localizations/uYouPlus.bundle/it.lproj/Localizable.strings
@@ -66,6 +66,9 @@
 "STOCK_VOLUME_HUD" = "Use iOS stock volume HUD";
 "STOCK_VOLUME_HUD_DESC" = "";
 
+"REPLACE_YT_DOWNLOAD_WITH_UYOU" = "Replace YouTube's download with uYou's";
+"REPLACE_YT_DOWNLOAD_WITH_UYOU_DESC" = "";
+
 // Video controls overlay options
 "VIDEO_CONTROLS_OVERLAY_OPTIONS" = "📹 Opzioni Sovrimpressione (Overlay) Video";
 

--- a/Localizations/uYouPlus.bundle/ja.lproj/Localizable.strings
+++ b/Localizations/uYouPlus.bundle/ja.lproj/Localizable.strings
@@ -66,6 +66,9 @@
 "STOCK_VOLUME_HUD" = "標準の音量HUDを利用する";
 "STOCK_VOLUME_HUD_DESC" = "";
 
+"REPLACE_YT_DOWNLOAD_WITH_UYOU" = "Replace YouTube's download with uYou's";
+"REPLACE_YT_DOWNLOAD_WITH_UYOU_DESC" = "";
+
 // Video controls overlay options
 "VIDEO_CONTROLS_OVERLAY_OPTIONS" = "📹 動画コントロールのオーバーレイ設定";
 

--- a/Localizations/uYouPlus.bundle/ko.lproj/Localizable.strings
+++ b/Localizations/uYouPlus.bundle/ko.lproj/Localizable.strings
@@ -66,6 +66,9 @@
 "STOCK_VOLUME_HUD" = "iOS 기본 음량 표시기 사용";
 "STOCK_VOLUME_HUD_DESC" = "";
 
+"REPLACE_YT_DOWNLOAD_WITH_UYOU" = "Replace YouTube's download with uYou's";
+"REPLACE_YT_DOWNLOAD_WITH_UYOU_DESC" = "";
+
 // Video controls overlay options
 "VIDEO_CONTROLS_OVERLAY_OPTIONS" = "📹 비디오 재생 오버레이 설정";
 

--- a/Localizations/uYouPlus.bundle/nl.lproj/Localizable.strings
+++ b/Localizations/uYouPlus.bundle/nl.lproj/Localizable.strings
@@ -66,6 +66,9 @@
 "STOCK_VOLUME_HUD" = "Use stock iOS volume HUD";
 "STOCK_VOLUME_HUD_DESC" = "";
 
+"REPLACE_YT_DOWNLOAD_WITH_UYOU" = "Replace YouTube's download with uYou's";
+"REPLACE_YT_DOWNLOAD_WITH_UYOU_DESC" = "";
+
 // Video controls overlay options
 "VIDEO_CONTROLS_OVERLAY_OPTIONS" = "📹 Video controls overlay options";
 

--- a/Localizations/uYouPlus.bundle/pl.lproj/Localizable.strings
+++ b/Localizations/uYouPlus.bundle/pl.lproj/Localizable.strings
@@ -66,6 +66,9 @@
 "STOCK_VOLUME_HUD" = "Użyj systemowego paska głośności";
 "STOCK_VOLUME_HUD_DESC" = "";
 
+"REPLACE_YT_DOWNLOAD_WITH_UYOU" = "Replace YouTube's download with uYou's";
+"REPLACE_YT_DOWNLOAD_WITH_UYOU_DESC" = "";
+
 // Video controls overlay options
 "VIDEO_CONTROLS_OVERLAY_OPTIONS" = "📹 Opcje wyglądu odtwarzacza video";
 

--- a/Localizations/uYouPlus.bundle/pt.lproj/Localizable.strings
+++ b/Localizations/uYouPlus.bundle/pt.lproj/Localizable.strings
@@ -66,6 +66,9 @@
 "STOCK_VOLUME_HUD" = "Usar o HUD de volume padrão do iOS";
 "STOCK_VOLUME_HUD_DESC" = "";
 
+"REPLACE_YT_DOWNLOAD_WITH_UYOU" = "Replace YouTube's download with uYou's";
+"REPLACE_YT_DOWNLOAD_WITH_UYOU_DESC" = "";
+
 // Video controls overlay options
 "VIDEO_CONTROLS_OVERLAY_OPTIONS" = "📹 Opções de Sobreposição de Controles de Vídeo";
 

--- a/Localizations/uYouPlus.bundle/ro.lproj/Localizable.strings
+++ b/Localizations/uYouPlus.bundle/ro.lproj/Localizable.strings
@@ -66,6 +66,9 @@
 "STOCK_VOLUME_HUD" = "Use stock iOS volume HUD";
 "STOCK_VOLUME_HUD_DESC" = "";
 
+"REPLACE_YT_DOWNLOAD_WITH_UYOU" = "Replace YouTube's download with uYou's";
+"REPLACE_YT_DOWNLOAD_WITH_UYOU_DESC" = "";
+
 // Video controls overlay options
 "VIDEO_CONTROLS_OVERLAY_OPTIONS" = "📹 Video controls overlay options";
 

--- a/Localizations/uYouPlus.bundle/ru.lproj/Localizable.strings
+++ b/Localizations/uYouPlus.bundle/ru.lproj/Localizable.strings
@@ -66,6 +66,9 @@
 "STOCK_VOLUME_HUD" = "Использовать стоковый слайдер грмкости iOS";
 "STOCK_VOLUME_HUD_DESC" = "";
 
+"REPLACE_YT_DOWNLOAD_WITH_UYOU" = "Replace YouTube's download with uYou's";
+"REPLACE_YT_DOWNLOAD_WITH_UYOU_DESC" = "";
+
 // Video controls overlay options
 "VIDEO_CONTROLS_OVERLAY_OPTIONS" = "📹 Параметры элементов оверлея видеоплеера";
 

--- a/Localizations/uYouPlus.bundle/template.lproj/Localizable.strings
+++ b/Localizations/uYouPlus.bundle/template.lproj/Localizable.strings
@@ -81,6 +81,9 @@ https://github.com/PoomSmart/Return-YouTube-Dislikes/tree/main/layout/Library/Ap
 "STOCK_VOLUME_HUD" = "Use stock iOS volume HUD";
 "STOCK_VOLUME_HUD_DESC" = "";
 
+"REPLACE_YT_DOWNLOAD_WITH_UYOU" = "Replace YouTube's download with uYou's";
+"REPLACE_YT_DOWNLOAD_WITH_UYOU_DESC" = "";
+
 // Video controls overlay options
 "VIDEO_CONTROLS_OVERLAY_OPTIONS" = "📹 Video controls overlay options";
 

--- a/Localizations/uYouPlus.bundle/tr.lproj/Localizable.strings
+++ b/Localizations/uYouPlus.bundle/tr.lproj/Localizable.strings
@@ -66,6 +66,9 @@
 "STOCK_VOLUME_HUD" = "Mevcut iOS baş yukarı göstergesi(HUD) alanını kullan";
 "STOCK_VOLUME_HUD_DESC" = "";
 
+"REPLACE_YT_DOWNLOAD_WITH_UYOU" = "Replace YouTube's download with uYou's";
+"REPLACE_YT_DOWNLOAD_WITH_UYOU_DESC" = "";
+
 // Video controls overlay options
 "VIDEO_CONTROLS_OVERLAY_OPTIONS" = "📹 Video Kontrolleri Kaplaması Seçenekleri";
 

--- a/Localizations/uYouPlus.bundle/vi.lproj/Localizable.strings
+++ b/Localizations/uYouPlus.bundle/vi.lproj/Localizable.strings
@@ -66,6 +66,9 @@
 "STOCK_VOLUME_HUD" = "Sử dụng thanh âm lượng mặc định của iOS";
 "STOCK_VOLUME_HUD_DESC" = "";
 
+"REPLACE_YT_DOWNLOAD_WITH_UYOU" = "Replace YouTube's download with uYou's";
+"REPLACE_YT_DOWNLOAD_WITH_UYOU_DESC" = "";
+
 // Video controls overlay options
 "VIDEO_CONTROLS_OVERLAY_OPTIONS" = "📹 Tùy chọn hiển thị trong trình phát video";
 

--- a/Localizations/uYouPlus.bundle/zh_cn.lproj/Localizable.strings
+++ b/Localizations/uYouPlus.bundle/zh_cn.lproj/Localizable.strings
@@ -66,6 +66,9 @@
 "STOCK_VOLUME_HUD" = "使用 iOS 自带音量指示";
 "STOCK_VOLUME_HUD_DESC" = "";
 
+"REPLACE_YT_DOWNLOAD_WITH_UYOU" = "Replace YouTube's download with uYou's";
+"REPLACE_YT_DOWNLOAD_WITH_UYOU_DESC" = "";
+
 // Video controls overlay options
 "VIDEO_CONTROLS_OVERLAY_OPTIONS" = "📹 视频播放器控制界面选项";
 

--- a/Localizations/uYouPlus.bundle/zh_tw.lproj/Localizable.strings
+++ b/Localizations/uYouPlus.bundle/zh_tw.lproj/Localizable.strings
@@ -66,6 +66,9 @@
 "STOCK_VOLUME_HUD" = "使用 iOS 內建的音量 HUD";
 "STOCK_VOLUME_HUD_DESC" = "";
 
+"REPLACE_YT_DOWNLOAD_WITH_UYOU" = "Replace YouTube's download with uYou's";
+"REPLACE_YT_DOWNLOAD_WITH_UYOU_DESC" = "";
+
 // Video controls overlay options
 "VIDEO_CONTROLS_OVERLAY_OPTIONS" = "📹 影片懸浮控制選項";
 

--- a/Sources/uYouPlus.h
+++ b/Sources/uYouPlus.h
@@ -19,6 +19,16 @@
 
 // #import <YouTubeHeader/YTISectionListRenderer.h> // Hide search ads by @PoomSmart - https://github.com/PoomSmart/YouTube-X
 
+// Replace YouTube's download with uYou's
+#import <YouTubeHeader/ELMPBShowActionSheetCommand.h>
+#import <YouTubeHeader/ELMPBElement.h>
+#import <YouTubeHeader/ELMPBProperties.h>
+#import <YouTubeHeader/ELMPBIdentifierProperties.h>
+#import <YouTubeHeader/YTMainAppControlsOverlayView.h>
+@interface YTMainAppControlsOverlayView(uYou)
+- (void)uYou;
+@end
+
 #define LOC(x) [tweakBundle localizedStringForKey:x value:nil table:nil]
 #define IS_ENABLED(k) [[NSUserDefaults standardUserDefaults] boolForKey:k]
 #define APP_THEME_IDX [[NSUserDefaults standardUserDefaults] integerForKey:@"appTheme"]
@@ -36,6 +46,7 @@ static NSString *const kHideRemixButton = @"hideRemixButton_enabled";
 static NSString *const kHideClipButton = @"hideClipButton_enabled";
 static NSString *const kHideDownloadButton = @"hideDownloadButton_enabled";
 static NSString *const kStockVolumeHUD = @"stockVolumeHUD_enabled";
+static NSString *const kReplaceYTDownloadWithuYou = @"kReplaceYTDownloadWithuYou_enabled";
 // Video controls overlay
 static NSString *const kHideAutoplaySwitch = @"hideAutoplaySwitch_enabled";
 static NSString *const kHideCC = @"hideCC_enabled";

--- a/Sources/uYouPlus.h
+++ b/Sources/uYouPlus.h
@@ -24,8 +24,8 @@
 #import <YouTubeHeader/ELMPBElement.h>
 #import <YouTubeHeader/ELMPBProperties.h>
 #import <YouTubeHeader/ELMPBIdentifierProperties.h>
-#import <YouTubeHeader/YTMainAppControlsOverlayView.h>
-@interface YTMainAppControlsOverlayView(uYou)
+// #import <YouTubeHeader/YTMainAppControlsOverlayView.h>
+@interface YTMainAppControlsOverlayView: UIView
 - (void)uYou;
 @end
 
@@ -77,8 +77,8 @@ static NSString *const kFlex = @"flex_enabled";
 @end
 
 // Hide autoplay switch / CC button
-@interface YTMainAppControlsOverlayView : UIView
-@end
+// @interface YTMainAppControlsOverlayView : UIView
+// @end
 
 // Skips content warning before playing *some videos - @PoomSmart
 @interface YTPlayabilityResolutionUserActionUIController : NSObject

--- a/Sources/uYouPlus.xm
+++ b/Sources/uYouPlus.xm
@@ -120,8 +120,19 @@ YTMainAppControlsOverlayView *controlsOverlayView;
         for (ELMPBElement *element in listOptions) {
             ELMPBProperties *properties = [element properties];
             ELMPBIdentifierProperties *identifierProperties = [properties firstSubmessage];
-            NSString *identifier = [identifierProperties identifier];
-            if ([identifier containsString:@"offline_upsell_dialog"]) {
+            // 19.30.2
+            if ([identifierProperties respondsToSelector:@selector(identifier)]) {
+                NSString *identifier = [identifierProperties identifier];
+                if ([identifier containsString:@"offline_upsell_dialog"]) {
+                    if ([controlsOverlayView respondsToSelector:@selector(uYou)]) {
+                        [controlsOverlayView uYou];
+                    }
+                    return;
+                }
+            }
+            // 19.20.2
+            NSString *description = [identifierProperties description];
+            if ([description containsString:@"offline_upsell_dialog"]) {
                 if ([controlsOverlayView respondsToSelector:@selector(uYou)]) {
                     [controlsOverlayView uYou];
                 }

--- a/Sources/uYouPlusPatches.h
+++ b/Sources/uYouPlusPatches.h
@@ -1,4 +1,5 @@
 #import <YouTubeHeader/YTCommonColorPalette.h>
+#import <YouTubeHeader/GOODialogView.h>
 #import "uYouPlus.h"
 
 @interface YTSingleVideoController : NSObject

--- a/Sources/uYouPlusPatches.xm
+++ b/Sources/uYouPlusPatches.xm
@@ -186,6 +186,59 @@ static void refreshUYouAppearance() {
 - (void)beginEnlargeAnimation {}
 %end
 
+%hook GOODialogView
+- (id)imageView {
+    UIImageView *imageView = %orig;
+
+    if ([[self titleLabel].text containsString:@"uYou\n"]) {
+        // // Invert uYou logo in download dialog if dark mode is enabled
+        // if ([[NSUserDefaults standardUserDefaults] integerForKey:@"page_style"] == 0)
+        //     return imageView;
+        // // https://gist.github.com/coryalder/3113a43734f5e0e4b497
+        // UIImage *image = [imageView image];
+        // CIImage *ciImage = [[CIImage alloc] initWithImage:image];
+        // CIFilter *filter = [CIFilter filterWithName:@"CIColorInvert"];
+        // [filter setDefaults];
+        // [filter setValue:ciImage forKey:kCIInputImageKey];
+        // CIContext *context = [CIContext contextWithOptions:nil];
+        // CIImage *output = [filter outputImage];
+        // CGImageRef cgImage = [context createCGImage:output fromRect:[output extent]];
+        // UIImage *icon = [UIImage imageWithCGImage:cgImage];
+        // CGImageRelease(cgImage);
+
+        // Load icon_clipped.png from uYouBundle.bundle
+        NSString *bundlePath = [[NSBundle mainBundle] pathForResource:@"uYouBundle" ofType:@"bundle"];
+        NSBundle *bundle = [NSBundle bundleWithPath:bundlePath];
+        NSString *iconPath = [bundle pathForResource:@"icon_clipped" ofType:@"png"];
+        UIImage *icon = [UIImage imageWithContentsOfFile:iconPath];
+        [imageView setImage:icon];
+
+        // Resize image to 30x30
+        // https://stackoverflow.com/a/2658801/19227228
+        CGSize size = CGSizeMake(30, 30);
+        UIGraphicsBeginImageContextWithOptions(size, NO, 0.0);
+        [icon drawInRect:CGRectMake(0, 0, size.width, size.height)];
+        UIImage *resizedImage = UIGraphicsGetImageFromCurrentImageContext();
+        UIGraphicsEndImageContext();
+
+        [imageView setImage:resizedImage];
+    }
+    
+    return imageView;
+}
+// Increase space between uYou label and video title
+- (id)titleLabel {
+    UILabel *titleLabel = %orig;
+    if ([titleLabel.text containsString:@"uYou\n"] &&
+        ![titleLabel.text containsString:@"uYou\n\n"]
+    ) {
+        NSString *text = [titleLabel.text stringByReplacingOccurrencesOfString:@"uYou\n" withString:@"uYou\n\n"];
+        [titleLabel setText:text];
+    }
+    return titleLabel;
+}
+%end
+
 %ctor {
     %init;
     // if (@available(iOS 16, *)) {

--- a/Sources/uYouPlusSettings.xm
+++ b/Sources/uYouPlusSettings.xm
@@ -295,6 +295,7 @@ extern NSBundle *uYouPlusBundle();
     SWITCH(LOC(@"HIDE_CLIP_BUTTON"), LOC(@"HIDE_CLIP_BUTTON_DESC"), kHideClipButton);
     SWITCH(LOC(@"HIDE_DOWNLOAD_BUTTON"), LOC(@"HIDE_DOWNLOAD_BUTTON_DESC"), kHideDownloadButton);
     SWITCH(LOC(@"STOCK_VOLUME_HUD"), LOC(@"STOCK_VOLUME_HUD_DESC"), kStockVolumeHUD);
+    SWITCH(LOC(@"REPLACE_YT_DOWNLOAD_WITH_UYOU"), LOC(@"REPLACE_YT_DOWNLOAD_WITH_UYOU_DESC"), kReplaceYTDownloadWithuYou);
 
     # pragma mark - Video controls overlay options
     SECTION_HEADER(LOC(@"VIDEO_CONTROLS_OVERLAY_OPTIONS"));


### PR DESCRIPTION
Known issue: replacing YouTube's download only works when triggered from the overlay of a playing video but not from feeds (either will result in "Error! No links found" or if a video is playing then that video will get downloaded).