### PR TITLE
Add shorts compatibility

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -28,7 +28,7 @@
 	branch = main
 [submodule "Extensions"]
 	path = Extensions
-	url = https://github.com/CokePokes/YoutubeExtensions.git
+	url = https://github.com/CrossiDev-Studio/OpenYoutubeAndShorts
 	branch = main
 [submodule "Tweaks/YTABConfig"]
 	path = Tweaks/YTABConfig


### PR DESCRIPTION
The currently used extension [Open in YouTube](https://github.com/CokePokes/YoutubeExtensions) is outdated and is not compatible with Shorts links. The repo has not seen commits in years. A fork of said repo, [OpenYoutubeAndShorts](https://github.com/CrossiDev-Studio/OpenYoutubeAndShorts), resolves this issue.

I have tested this personally and it works with uYouPlus 3.0.4-20.08.3 on iOS 18.3.1.