### PR TITLE
Update buildapp.yml

### DIFF
--- a/.github/workflows/buildapp.yml
+++ b/.github/workflows/buildapp.yml
@@ -79,7 +79,7 @@ jobs:
       
       - name: Caching SDK
         id: SDK
-        uses: actions/cache@v4.1.1
+        uses: actions/cache@v4
         env:
           cache-name: iOS-16.5-SDK
         with:


### PR DESCRIPTION

A fix of this error

Error: This request has been automatically failed because it uses a deprecated version of actions/cache: v4.1.1. Please update your workflow to use v3/v4 of actions/cache to avoid interruptions. Learn more: https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down